### PR TITLE
Add required providers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ export TF_VAR_hcloud_token
 
 Create a `main.tf` file in a new directory with the following contents:
 
-```hcl
+```terraform {
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+      version = "1.23.0"
+    }
+  }
+}
+
+hcl
 provider "hcloud" {
   token = var.hcloud_token
 }


### PR DESCRIPTION
The required providers sections is now needed in the Terraform configuration
https://www.terraform.io/docs/configuration/provider-requirements.html